### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.5",
         "php-di/php-di": "~5.0",
-        "acclimate/container": "~1.0",
+        "acclimate/container": "~1.0 || ~2.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.0",
         "phpmd/phpmd" : "~2.0",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "~4.8.35",
         "zendframework/zendframework": "^2.5"
     },
 

--- a/tests/DI/ZendFramework2/Service/CacheFactory/CacheFactoryTest.php
+++ b/tests/DI/ZendFramework2/Service/CacheFactory/CacheFactoryTest.php
@@ -11,13 +11,14 @@ use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\Common\Cache\RedisCache;
 use Zend\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CacheFactoryTest
  * @author mfris
  * @package Test\DI\ZendFramework2\Service
  */
-class CacheFactoryTest extends \PHPUnit_Framework_TestCase
+class CacheFactoryTest extends TestCase
 {
 
     /**

--- a/tests/DI/ZendFramework2/Service/DIContainerFactoryTest.php
+++ b/tests/DI/ZendFramework2/Service/DIContainerFactoryTest.php
@@ -13,13 +13,14 @@ use Doctrine\Common\Cache\ArrayCache;
 use Test\DI\ZendFramework2\Helper\Config;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DIContainerFactoryTest
  * @author mfris
  * @package Test\DI\ZendFramework2\Service
  */
-class DIContainerFactoryTest extends \PHPUnit_Framework_TestCase
+class DIContainerFactoryTest extends TestCase
 {
 
     /**

--- a/tests/DI/ZendFramework2/Service/PHPDIAbstractFactoryTest.php
+++ b/tests/DI/ZendFramework2/Service/PHPDIAbstractFactoryTest.php
@@ -13,11 +13,12 @@ use DI\Container;
 use DI\ContainerBuilder;
 use DI\ZendFramework2\Service\PHPDIAbstractFactory;
 use Zend\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class PHPDIAbstractFactoryTest extends \PHPUnit_Framework_TestCase
+class PHPDIAbstractFactoryTest extends TestCase
 {
     /**
      * @var Container

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -14,11 +14,12 @@ use DI\ContainerBuilder;
 use DI\ZendFramework2\Service\PHPDIAbstractFactory;
 use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends TestCase
 {
     /**
      * @var Container


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.